### PR TITLE
Update repository URL in README.rst and setup.py

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -37,4 +37,4 @@ Bugs and requests
 
 If you have found a bug or if you have a request for additional functionality, please use the issue tracker on GitHub.
 
-https://github.com/Baguage/django-google-analytics/issues
+https://github.com/Baguage/django-google-analytics-id/issues

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     license='BSD License',
     description='Django application to add your Google analytics code to your website template(s)',
     long_description=README,
-    url='https://www.example.com/',
+    url='https://github.com/Baguage/django-google-analytics-id',
     author='Alex Vyushkov',
     author_email='alex.vyushkov@gmail.com',
     classifiers=[


### PR DESCRIPTION
setup URL arg was: .../example.com
readme issues link was: .../django-google-analytics (no -id at end)

A tiny change, but otherwise there is no working link to the repository from PyPI...

Thanks for sharing your code!